### PR TITLE
Add maintenance_window and backup_window variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Created with [terraform-docs](https://github.com/terraform-docs/terraform-docs)
 | <a name="input_rds_username"></a> [rds\_username](#input\_rds\_username) | The username for RDS | `string` | n/a | yes |
 | <a name="input_read_replica_enabled"></a> [read\_replica\_enabled](#input\_read\_replica\_enabled) | Create a read replica or not | `bool` | `false` | no |
 | <a name="input_read_replica_rds_instance"></a> [read\_replica\_rds\_instance](#input\_read\_replica\_rds\_instance) | What size read replica to create | `string` | `"db.t2.small"` | no |
+| <a name="input\backup_window"></a> [backup\_window](#input\_backup\_window) | When to perform backups on the RDS instance | `string` | `04:00-06:00` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | When to perform maintenance on the RDS instance | `string` | `sun:06:00-sun:08:00` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to deploy in | `string` | `"us-east-1"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS Resource tags | `map(string)` | `{}` | no |
 | <a name="input_use_actions_endpoint"></a> [use\_actions\_endpoint](#input\_use\_actions\_endpoint) | Whether or not to create the custom actions endpoint container | `bool` | `false` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -24,11 +24,11 @@ resource "aws_db_instance" "hasura" {
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = true
   apply_immediately           = true
-  maintenance_window          = "sun:06:00-sun:08:00"
+  maintenance_window          = var.maintenance_window
   skip_final_snapshot         = false
   copy_tags_to_snapshot       = true
   backup_retention_period     = 7
-  backup_window               = "04:00-06:00"
+  backup_window               = var.backup_window
   final_snapshot_identifier   = "hasura"
   deletion_protection         = true
 
@@ -54,11 +54,11 @@ resource "aws_db_instance" "read_replica_hasura" {
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = true
   apply_immediately           = true
-  maintenance_window          = "sun:06:00-sun:08:00"
+  maintenance_window          = var.maintenance_window
   skip_final_snapshot         = false
   copy_tags_to_snapshot       = true
   backup_retention_period     = 0
-  backup_window               = "04:00-06:00"
+  backup_window               = var.backup_window
   final_snapshot_identifier   = "hasura"
   deletion_protection         = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -248,6 +248,18 @@ variable "read_replica_rds_instance" {
   description = "What size read replica to create"
 }
 
+variable "maintenance_window" {
+  type        = string
+  description = "When to perform maintenance on the RDS instance"
+  default = "sun:06:00-sun:08:00"
+}
+
+variable "backup_window" {
+  type        = string
+  description = "When to perform backups on the RDS instance"
+  default     = "04:00-06:00"
+}
+
 ########################################################
 # Variables controlling the actions endpoints container
 ########################################################


### PR DESCRIPTION
## Changes
- Adds `maintenance_window` and `backup_window` as optional variables. This makes it easier for this instance to work with AWS backup instances that might be set to different times than here.
- Updates documentation for the new variables